### PR TITLE
Fix `hhdb` value in base.yaml

### DIFF
--- a/rf2aa/config/inference/base.yaml
+++ b/rf2aa/config/inference/base.yaml
@@ -3,7 +3,7 @@ output_path: ""
 checkpoint_path: RFAA_paper_weights.pt
 database_params:
   sequencedb: ""
-  hhdb: "pdb100_2022Apr19/pdb100_2022Apr19"
+  hhdb: "pdb100_2021Mar03/pdb100_2021Mar03"
   command: make_msa.sh
   num_cpus: 4
   mem: 64


### PR DESCRIPTION
* Fixes the `hhdb` value in base.yaml to point to the version of the templates databases that users are instructed to download in `README.md`.