### PR TITLE
Update merge_inputs.py

### DIFF
--- a/rf2aa/data/merge_inputs.py
+++ b/rf2aa/data/merge_inputs.py
@@ -73,8 +73,8 @@ def merge_protein_inputs(protein_inputs, deterministic: bool = False):
         chain_lengths = list(zip(protein_inputs.keys(), lengths_list))
 
         merged_input = RawInputData(
-            a3m_out["msa"],
-            a3m_out["ins"],
+            a3m_out[0],
+            a3m_out[1],
             bond_feats,
             xyz_t[:max_template_dim],
             mask_t[:max_template_dim],


### PR DESCRIPTION
Multimer prediction shows below error.

Traceback (most recent call last):
  File "/Pass/to/RFAA/RoseTTAFold-All-Atom/rf2aa/run_inference.py", line 206, in main
    runner.infer()
  File "/Pass/to/RFAA/RoseTTAFold-All-Atom/rf2aa/run_inference.py", line 153, in infer
    self.parse_inference_config()
  File "/Pass/to/RFAA/RoseTTAFold-All-Atom/rf2aa/run_inference.py", line 93, in parse_inference_config
    raw_data = merge_all(protein_inputs, na_inputs, sm_inputs, residues_to_atomize, deterministic=self.deterministic)
  File "/Pass/to/RFAA/RoseTTAFold-All-Atom/rf2aa/data/merge_inputs.py", line 169, in merge_all
    protein_inputs, protein_chain_lengths = merge_protein_inputs(protein_inputs, deterministic=deterministic)
  File "/Pass/to/RFAA/RoseTTAFold-All-Atom/rf2aa/data/merge_inputs.py", line 76, in merge_protein_inputs
    a3m_out["msa"],
TypeError: tuple indices must be integers or slices, not str

a3m_out was defined like below 
    a3m_out = merge_a3m_homo(msa, ins, len(hash_list))