### PR TITLE
Fix issue in complexes with RNA structures

### DIFF
--- a/rf2aa/data/parsers.py
+++ b/rf2aa/data/parsers.py
@@ -227,7 +227,7 @@ def parse_multichain_fasta(filename,  maxseq=10000, rna_alphabet=False, dna_alph
 
     # convert letters into numbers
     if rna_alphabet:
-        alphabet = np.array(list("00000000000000000000-000000ACGTN"), dtype='|S1').view(np.uint8)
+        alphabet = np.array(list("00000000000000000000-000000ACGUN"), dtype='|S1').view(np.uint8)
     elif dna_alphabet:
         alphabet = np.array(list("00000000000000000000-0ACGTD00000"), dtype='|S1').view(np.uint8)
     else:


### PR DESCRIPTION
As described in issue #57 and #110, RNA features are converted incorrectly as the `U` bases is not mapped to the correct integer. This simple change fixed the issue for me