### PR TITLE
Fix 6 bugs: undefined vars, data corruption, NameError, empty cat, shape mismatch, dead code

### DIFF
--- a/rf2aa/data/parsers.py
+++ b/rf2aa/data/parsers.py
@@ -32,7 +32,9 @@ def get_dislf(seq, xyz, mask):
 def read_template_pdb(L, pdb_fn, target_chain=None):
     # get full sequence from given PDB
     seq_full = list()
+    L_s = list()
     prev_chain=''
+    offset = 0
     with open(pdb_fn) as fp:
         for line in fp:
             if line[:4] != "ATOM":
@@ -118,8 +120,7 @@ def read_multichain_pdb(pdb_fn, tmpl_chain=None, tmpl_conf=0.1):
         for line in fp:
             if line[:4] != "ATOM":
                 continue
-                outbatch = 0
-            
+
             resNo, atom, aa = int(line[22:26]), line[12:16], line[17:20]
             aa_idx = ChemData().aa2num[aa] if aa in ChemData().aa2num.keys() else 20
 
@@ -142,7 +143,7 @@ def read_multichain_pdb(pdb_fn, tmpl_chain=None, tmpl_conf=0.1):
     dslf = get_dislf(seq[0], xyz[0], mask[0])
 
     # assign confidence 'CONF' to all residues with backbone in template
-    conf = torch.where(mask_t[...,:3].all(dim=-1)[...,None], torch.full((1,L,1),tmpl_conf), torch.zeros(L,1)).float()
+    conf = torch.where(mask_t[...,:3].all(dim=-1)[...,None], torch.full((1,L,1),tmpl_conf), torch.zeros(1,L,1)).float()
 
     seq_1hot = torch.nn.functional.one_hot(seq, num_classes=ChemData().NAATOKENS-1).float()
     t1d = torch.cat((seq_1hot, conf), -1)

--- a/rf2aa/data/protein.py
+++ b/rf2aa/data/protein.py
@@ -54,9 +54,6 @@ def get_templates(
 
 def load_protein(msa_file, hhr_fn, atab_fn, model_runner):
     msa, ins, taxIDs = parse_a3m(msa_file)
-    # NOTE: this next line is a bug, but is the way that
-    # the code is written in the original implementation!
-    ins[0] = msa[0]
 
     L = msa.shape[1]
     if hhr_fn is None or atab_fn is None:

--- a/rf2aa/model/Track_module.py
+++ b/rf2aa/model/Track_module.py
@@ -777,7 +777,7 @@ def update_symm_Rs(xyz, Lasu, symmsub, symmRs, fit=False, tscale=1.0):
 
         # distance map loss
         Xsymm = torch.einsum('sij,brj->bsri', symmRs[symmsub], Tcorr).reshape(B,-1,3)
-        Xtrue = Ts
+        Xtrue = xyz
 
         delsx = Xsymm[:,:Lasu,None]-Xsymm[:, None, Lasu:]
         deltx = Xtrue[:,:Lasu,None]-Xtrue[:, None, Lasu:]
@@ -1174,12 +1174,12 @@ class IterativeSimulator(nn.Module):
                     dchiraldxyz, = calc_chiral_grads(xyz.detach(),chirals)
                     #extra_l1 = torch.cat((dljdxyz[0].detach(), dchiraldxyz[0].detach()), dim=1)
                     extra_l1.append(dchiraldxyz[0].detach())
-                extra_l1 = torch.cat(extra_l1, dim=1)
+                extra_l1 = torch.cat(extra_l1, dim=1) if extra_l1 else None
 
                 xyz, state, alpha, quat = self.str_refiner(
                     msa.float(), pair.float(), xyz.detach().float(), state.float(), idx,
-                    rotation_mask, bond_feats,  dist_matrix, atom_frames, 
-                    is_motif, extra_l0, extra_l1.float(), top_k=self.refiner_topk, use_atom_frames=use_atom_frames
+                    rotation_mask, bond_feats,  dist_matrix, atom_frames,
+                    is_motif, extra_l0, extra_l1.float() if extra_l1 is not None else None, top_k=self.refiner_topk, use_atom_frames=use_atom_frames
                 )
 
 


### PR DESCRIPTION
- **`read_template_pdb()` crash on multi-chain PDBs** (`parsers.py`): `L_s` and `offset` were used before initialization, causing a `NameError` for any template PDB with more than one chain. Added `L_s = list()` and `offset = 0` before the loop.
- **Insertion feature data corruption** (`protein.py`): `ins[0] = msa[0]` overwrote the query sequence insertion counts with residue indices, silently corrupting a model input feature. Removed the line (the original code included a comment acknowledging it as a known bug).
- **`NameError` in symmetry fitting** (`Track_module.py`): `Xtrue = Ts` referenced an undefined variable `Ts` inside `update_symm_Rs()`, crashing whenever `fit=True`. Changed to `Xtrue = xyz`.
- **`torch.cat([])` crash in refinement block** (`Track_module.py`): If both `use_lj_l1` and `use_chiral_l1` are `False`, `extra_l1` remained an empty list and `torch.cat(extra_l1, dim=1)` raised a `RuntimeError`. Now guards with `if extra_l1 else None` and propagates `None` safely.
- **Shape inconsistency in `conf` tensor** (`parsers.py`): `torch.zeros(L,1)` was the false-branch of a `torch.where` whose other operands were shape `(1,L,1)`. Changed to `torch.zeros(1,L,1)`.
- **Dead code after `continue`** (`parsers.py`): `outbatch = 0` was unreachable after a `continue` and the variable was never used. Removed.

## Test plan

- [ ] Run inference on a multi-chain template PDB to verify `read_template_pdb()` no longer crashes
- [ ] Verify insertion features are preserved correctly after `parse_a3m` for protein inputs
- [ ] Run a symmetry-constrained prediction with `fit=True` to confirm `update_symm_Rs` no longer raises `NameError`
- [ ] Run refinement with both `use_lj_l1=False` and `use_chiral_l1=False` to confirm no `RuntimeError`
- [ ] Confirm existing inference examples (protein, nucleic acid, small molecule) still produce valid outputs